### PR TITLE
Added support for per-channel timezone offsets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,24 @@ Configuration is done inside logbot.py.
     python logbot.py
 
 Example logs at https://raw.github.com/excid3/logbot/master/example_logs/2011-10-22.html
+
+
+Channels with localised time
+-----
+LogBot now also supports having localised time on a per channel basis using the pytz library, allowing you to have the logs of specific channels use different timezones.
+Installing pytz should be as simple as running `easy_install --upgrade pytz`, see http://pytz.sourceforge.net/#installation for details.
+Don't worry, if you don't have pytz installed, LogBot will continue to show the logs timestamped with your system's localtime as it used to.
+
+Next you can create a simple text file at `~/.logbot-channel_locations.conf` (or wherever `CHANNEL_LOCATIONS_FILE` in logbot.py points to).
+On each line you can now specify a channel name, and the timezone location of which it should use the timezone offset, separated by a space. Example:
+
+	#excid3 America/Chicago
+	#netherlands Europe/Amsterdam
+	#aloha US/Hawaii
+	#space UTC
+
+Any channel not specified in this file will use the default timezone as specified in DEFAULT_TIMEZONE, which defaults to 'UTC'.
+
+If you want to see a list of all possible timezone location names you can use, run:
+
+    python -c 'import pytz;print pytz.all_timezones'

--- a/logbot.py
+++ b/logbot.py
@@ -383,7 +383,7 @@ class Logbot(SingleServerIRCBot):
         self.channel_locations = {}
         if os.path.exists(CHANNEL_LOCATIONS_FILE):
             f = open(CHANNEL_LOCATIONS_FILE, 'r')
-            self.channel_locations = dict((k.lower(), v) for k, v in dict([line.split(None,1) for line in f.readlines()]).iteritems())
+            self.channel_locations = dict((k.lower(), v) for k, v in dict([line.strip().split(None,1) for line in f.readlines()]).iteritems())
 
 def connect_ftp():
     print "Using FTP %s..." % (FTP_SERVER)

--- a/logbot.py
+++ b/logbot.py
@@ -38,6 +38,10 @@ import os
 import ftplib
 import sys
 from time import strftime
+try:
+    from datetime import datetime
+    from pytz import timezone
+except: pass
 
 try:
     from hashlib import md5
@@ -83,6 +87,8 @@ FTP_FOLDER = ""
 # The amount of messages to wait before uploading to the FTP server
 FTP_WAIT = 25
 
+CHANNEL_LOCATIONS_FILE = os.path.expanduser("~/.logbot-channel_locations.conf")
+DEFAULT_TIMEZONE = 'UTC'
 
 default_format = {
     "help" : HELP_MESSAGE,
@@ -167,6 +173,7 @@ class Logbot(SingleServerIRCBot):
         self.count = 0
         self.nick_pass = nick_pass
 
+        self.load_channel_locations()
         print "Logbot %s" % __version__
         print "Connecting to %s:%i..." % (server, port)
         print "Press Ctrl-C to quit"
@@ -265,8 +272,14 @@ class Logbot(SingleServerIRCBot):
             append_line("%s/index.html" % LOG_FOLDER, '<a href="%s/index.html">%s</a>' % (channel.replace("#", "%23"), channel_title))
 
         # Current log
-        time = strftime("%H:%M:%S")
-        date = strftime("%Y-%m-%d")
+        try:
+            localtime = datetime.now(timezone(self.channel_locations.get(channel,DEFAULT_TIMEZONE)))
+            time = localtime.strftime("%H:%M:%S")
+            date = localtime.strftime("%Y-%m-%d")
+        except:
+            time = strftime("%H:%M:%S")
+            date = strftime("%Y-%m-%d")
+
         log_path = "%s/%s/%s.html" % (LOG_FOLDER, channel, date)
 
         # Create the log date index if it doesnt exist
@@ -364,6 +377,16 @@ class Logbot(SingleServerIRCBot):
     def on_topic(self, c, e):
         self.write_event("topic", e)
 
+    # Loads the channel - timezone-location pairs from the CHANNEL_LOCATIONS_FILE
+    # Each line is expected to have the channelname and (pytz) TimeZone location separated by a space
+    # Example: 
+    # #excid3 UTC
+    # #Netherlands Europe/Amsterdam
+    def load_channel_locations(self):
+        self.channel_locations = {}
+        if os.path.exists(CHANNEL_LOCATIONS_FILE):
+            f = open(CHANNEL_LOCATIONS_FILE, 'r')
+            self.channel_locations = dict([line.split() for line in f.readlines()])
 
 def connect_ftp():
     print "Using FTP %s..." % (FTP_SERVER)

--- a/logbot.py
+++ b/logbot.py
@@ -378,15 +378,12 @@ class Logbot(SingleServerIRCBot):
         self.write_event("topic", e)
 
     # Loads the channel - timezone-location pairs from the CHANNEL_LOCATIONS_FILE
-    # Each line is expected to have the channelname and (pytz) TimeZone location separated by a space
-    # Example: 
-    # #excid3 UTC
-    # #Netherlands Europe/Amsterdam
+    # See the README for details and example
     def load_channel_locations(self):
         self.channel_locations = {}
         if os.path.exists(CHANNEL_LOCATIONS_FILE):
             f = open(CHANNEL_LOCATIONS_FILE, 'r')
-            self.channel_locations = dict([line.split() for line in f.readlines()])
+            self.channel_locations = dict((k.lower(), v) for k, v in dict([line.split(None,1) for line in f.readlines()]).iteritems())
 
 def connect_ftp():
     print "Using FTP %s..." % (FTP_SERVER)


### PR DESCRIPTION
You can now create a file at CHANNEL_LOCATIONS_FILE that contains a
list of channels and (pytz) timezone location names.
All log files for specified channels from that point on will have their
timestamps adjusted to the given timezone.
If a channel is not specified in the config file, it will default to
the timezone specified by DEFAULT_TIMEZONE (which defaults to UTC).

I've started storing this info in a separate config file as I plan to
move all the other settings into a config file as well so people don't
need to edit the script (allowing the script to be re-used more easily).
